### PR TITLE
Updated formatting for codebase using gofmt

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -13,7 +13,7 @@ type consumer struct {
 }
 
 func newConsumer(ctx context.Context, ch *chan internalMessage, handler func(string, interface{})) *consumer {
-	return &consumer{ctx, ch, NewLogger(ctx), handler, }
+	return &consumer{ctx, ch, NewLogger(ctx), handler}
 }
 
 func (c *consumer) run() {
@@ -21,7 +21,7 @@ func (c *consumer) run() {
 		c.logger.Debug("Start")
 		for {
 			select {
-			case <- c.ctx.Done():
+			case <-c.ctx.Done():
 				c.logger.Debug("stop")
 				return
 			case m, ok := <-*c.channel:

--- a/context.go
+++ b/context.go
@@ -7,11 +7,11 @@ import (
 )
 
 const (
-	EngineKey   = "engine-name"
-	TopicKey    = "topic-name"
-	ConsumerKey = "consumer-id"
-	ProducerKey = "producer-id"
-	LogLevelKey = "log-level"
+	EngineKey     = "engine-name"
+	TopicKey      = "topic-name"
+	ConsumerKey   = "consumer-id"
+	ProducerKey   = "producer-id"
+	LogLevelKey   = "log-level"
 	ProducerValue = "Producer"
 )
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -29,15 +29,15 @@ func TestEngine_Publish_Error(t *testing.T) {
 	}{
 		{
 			"NoTopic",
-			fields{ "testEngine", logrus.ErrorLevel, },
-			args{ topicName, "message"},
+			fields{"testEngine", logrus.ErrorLevel},
+			args{topicName, "message"},
 			true,
 			fmt.Sprintf("topic %s does not exists", topicName),
 			false,
-		},{
+		}, {
 			"TopicStopped",
-			fields{ "testEngine", logrus.ErrorLevel, },
-			args{ topicName, "message"},
+			fields{"testEngine", logrus.ErrorLevel},
+			args{topicName, "message"},
 			true,
 			"topic closed",
 			true,
@@ -50,7 +50,7 @@ func TestEngine_Publish_Error(t *testing.T) {
 				tt.fields.logLevel,
 			)
 			if tt.startTopic {
-				ge.AddTopic(topicName, func(topic string, obj interface{}){})
+				ge.AddTopic(topicName, func(topic string, obj interface{}) {})
 				ge.Stop()
 			}
 			err := ge.Publish(tt.args.name, tt.args.obj)
@@ -70,12 +70,12 @@ func TestEngine_Publish_Error(t *testing.T) {
 func TestEngine_Publish(t *testing.T) {
 	testName := "publish & Consume"
 	t.Run(testName, func(t *testing.T) {
-		ge := NewEngine(testName, logrus.ErrorLevel, )
+		ge := NewEngine(testName, logrus.ErrorLevel)
 
 		topicName := "topic"
 		msg := "Test Message"
 
-		ge.AddTopic(topicName, func(topic string, obj interface{}){
+		ge.AddTopic(topicName, func(topic string, obj interface{}) {
 			if strings.Compare(fmt.Sprintf("%v", obj), msg) != 0 {
 				t.Errorf("publish() received = '%v', expected '%v'", obj, msg)
 			} else if strings.Compare(topicName, topic) != 0 {
@@ -101,22 +101,22 @@ func TestEngine_Publish_Multiple_Topics(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		numTopics int
+		name         string
+		numTopics    int
 		numConsumers int
 	}{
-		{ "Two topics", 2, 1, },
-		{ "Three topics twenty Consumers", 3, 20, },
-		{ "Five topics", 5, 1, },
-		{ "Five topics two Consumers", 5, 2, },
-		{ "Twenty topics five Consumers", 20, 5, },
+		{"Two topics", 2, 1},
+		{"Three topics twenty Consumers", 3, 20},
+		{"Five topics", 5, 1},
+		{"Five topics two Consumers", 5, 2},
+		{"Twenty topics five Consumers", 20, 5},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ge := NewEngine(tt.name, logrus.ErrorLevel, )
+			ge := NewEngine(tt.name, logrus.ErrorLevel)
 			for i := 0; i < tt.numTopics; i++ {
-				topicName := fmt.Sprintf("%s-%d",baseTopicName,i)
+				topicName := fmt.Sprintf("%s-%d", baseTopicName, i)
 				ge.AddTopic(topicName, func(topic string, obj interface{}) {
 					received := obj.(Message)
 					if strings.Compare(received.topic, topic) != 0 {
@@ -126,9 +126,9 @@ func TestEngine_Publish_Multiple_Topics(t *testing.T) {
 			}
 
 			var wg sync.WaitGroup
-			for i := 0; i < tt.numTopics - 1; i++ {
+			for i := 0; i < tt.numTopics-1; i++ {
 				wg.Add(1)
-				topicName := fmt.Sprintf("%s-%d",baseTopicName,i)
+				topicName := fmt.Sprintf("%s-%d", baseTopicName, i)
 				go func(topic string) {
 					msg := Message{topicName, baseMsg}
 					err := ge.Publish(topicName, msg)
@@ -139,7 +139,7 @@ func TestEngine_Publish_Multiple_Topics(t *testing.T) {
 				}(topicName)
 			}
 			wg.Add(1)
-			topicName := fmt.Sprintf("%s-%d",baseTopicName,tt.numTopics - 1)
+			topicName := fmt.Sprintf("%s-%d", baseTopicName, tt.numTopics-1)
 			msg := Message{topicName, baseMsg}
 			err := ge.Publish(topicName, msg)
 			if err != nil {

--- a/examples/example.go
+++ b/examples/example.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-	"github.com/acjzz/gokaf"
 	"fmt"
+	"github.com/acjzz/gokaf"
 	"github.com/sirupsen/logrus"
 	"time"
 )
 
-func main(){
+func main() {
 	ge := gokaf.NewEngine("MyEngine", logrus.DebugLevel)
 
-	topics := []string { "Topic0", "Topic1" }
+	topics := []string{"Topic0", "Topic1"}
 
 	for _, topicName := range topics {
 		// Register different Handler per each Topic as well as the Topics themselves
@@ -22,7 +22,7 @@ func main(){
 		})
 	}
 
-	go func(){
+	go func() {
 		for i := 1; i <= 1000; i++ {
 			// Simulation of High Frequency Data Stream
 			e := ge.Publish(topics[0], fmt.Sprintf("High Frequency Message%d", i))
@@ -30,7 +30,7 @@ func main(){
 				fmt.Printf("publishing to topic %s, err: %v", topics[0], e)
 				break
 			}
-			time.Sleep(time.Millisecond/100)
+			time.Sleep(time.Millisecond / 100)
 		}
 	}()
 

--- a/message.go
+++ b/message.go
@@ -1,9 +1,9 @@
 package gokaf
 
 type internalMessage struct {
-	value	interface{}
+	value interface{}
 }
 
 func newInternalMessage(value interface{}) internalMessage {
-	return internalMessage{value }
+	return internalMessage{value}
 }

--- a/producer_test.go
+++ b/producer_test.go
@@ -1,7 +1,7 @@
 package gokaf
 
 import (
-"context"
+	"context"
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"strings"
@@ -17,7 +17,7 @@ func Test_producer(t *testing.T) {
 		var channel chan internalMessage
 		p := newProducer(ctx, &channel)
 		cancel()
-		err :=p.publish(internalMessage{"test"})
+		err := p.publish(internalMessage{"test"})
 		if err == nil {
 			t.Errorf("publish() wanted error")
 		} else {

--- a/topic_test.go
+++ b/topic_test.go
@@ -18,7 +18,7 @@ func TestTopic_Publish(t *testing.T) {
 		topic := NewTopic(
 			ctx,
 			topicName,
-			func(topic string, obj interface{}){
+			func(topic string, obj interface{}) {
 				if strings.Compare(fmt.Sprintf("%v", obj), msg.value.(string)) != 0 {
 					t.Errorf("publish() received = '%v', expected '%v'", obj, msg)
 				} else if strings.Compare(topicName, topic) != 0 {


### PR DESCRIPTION
> Formatting issues are the most contentious but the least consequential. - golang.org

To solve formatting concerns, golang provides `gofmt` for formatting
code and align with the approach. In this commit, I used gofmt to align
with the formatting suggested by golang

### Command used:
```go
gofmt -w .
```

### References
https://golang.org/doc/effective_go.html#formatting